### PR TITLE
enable state management and refresh indicator at home page's tab

### DIFF
--- a/lib/infrastructure/firebase/photo/firebase_photo_repository.dart
+++ b/lib/infrastructure/firebase/photo/firebase_photo_repository.dart
@@ -37,7 +37,9 @@ class FirebasePhotoRepository implements IPhotoRepository {
     for (final photo in photoList) {
       final imageRef = storageRef.child(photo.path.value);
 
-      await imageRef.putData(photo.data);
+      final metaData = SettableMetadata(contentType: "image/jpg");
+
+      await imageRef.putData(photo.data, metaData);
     }
   }
 

--- a/lib/presentation/components/widgets/question_card_list_widget.dart
+++ b/lib/presentation/components/widgets/question_card_list_widget.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../domain/shared/subject.dart';
+import '../../controllers/get_recommended_quesiotns_controller/get_recommended_questions_controller.dart';
+import '../../shared/constants/color_set.dart';
+import '../../shared/constants/padding_set.dart';
+import '../parts/text_for_error.dart';
+import '../parts/text_for_no_question_found.dart';
+import 'question_and_answer_card_skeleton_widget.dart';
+import 'question_and_answer_card_widget.dart';
+
+class QuestionCardListWidget extends StatefulHookConsumerWidget {
+  const QuestionCardListWidget({super.key, required this.subject});
+
+  final Subject? subject;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _QuestionCardListWidget();
+}
+
+class _QuestionCardListWidget extends ConsumerState<QuestionCardListWidget>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+
+    final getRecommendedQuestionsState =
+        ref.watch(getRecommendedQuestionsControllerProvider(widget.subject));
+
+    return getRecommendedQuestionsState.when(
+      data: (recommendedQuestions) => recommendedQuestions.isNotEmpty
+          ? RefreshIndicator(
+              backgroundColor: ColorSet.of(context).primary,
+              color: ColorSet.of(context).whiteText,
+              onRefresh: () async {
+                ref.invalidate(
+                    getRecommendedQuestionsControllerProvider(widget.subject));
+              },
+              child: ListView.builder(
+                itemCount: recommendedQuestions.length,
+                itemBuilder: (context, index) {
+                  final recommendedQuestion = recommendedQuestions[index];
+                  return Padding(
+                    padding: EdgeInsets.only(
+                      top: PaddingSet.getPaddingSize(
+                        context,
+                        30,
+                      ),
+                      right: PaddingSet.getPaddingSize(
+                        context,
+                        20,
+                      ),
+                      left: PaddingSet.getPaddingSize(
+                        context,
+                        20,
+                      ),
+                      bottom: index == recommendedQuestions.length - 1
+                          ? PaddingSet.getPaddingSize(
+                              context,
+                              20,
+                            )
+                          : 0,
+                    ),
+                    child: QuestionAndAnswerCardWidget(
+                      questionCardDto: recommendedQuestion,
+                    ),
+                  );
+                },
+              ),
+            )
+          : const Center(
+              child: TextForNoQuestionFound(),
+            ),
+      loading: () => ListView.builder(
+        itemCount: 10,
+        itemBuilder: (context, index) {
+          return Padding(
+            padding: EdgeInsets.only(
+                top: PaddingSet.getPaddingSize(
+                  context,
+                  30,
+                ),
+                right: PaddingSet.getPaddingSize(
+                  context,
+                  20,
+                ),
+                left: PaddingSet.getPaddingSize(
+                  context,
+                  20,
+                )),
+            child: const QuestionAndAnswerCardSkeletonWidget(),
+          );
+        },
+      ),
+      error: (error, stack) {
+        return const Center(
+          child: TextForError(),
+        );
+      },
+      skipLoadingOnRefresh: false, // refreshしたときにshimmer effectを追加。
+    );
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}

--- a/lib/presentation/components/widgets/question_card_list_widget.dart
+++ b/lib/presentation/components/widgets/question_card_list_widget.dart
@@ -99,7 +99,6 @@ class _QuestionCardListWidget extends ConsumerState<QuestionCardListWidget>
           child: TextForError(),
         );
       },
-      skipLoadingOnRefresh: false, // refreshしたときにshimmer effectを追加。
     );
   }
 


### PR DESCRIPTION
# 行ったこと
- ホーム画面のタブにおいて、状態管理を有効化し、不必要なfirebaseとの接続を減らす
- 全科目を一度に取得するのではなく、各科目を初回表示の時のみfirebaseと通信
- refreshを有効化した

# 森脇に確認してほしいこと
- 挙動確認(大して変わってはない)
- refreshしたときの動作を考えてほしい
  - shimmer effectをrefreshしたときに入れるか
  - 具体的なことは該当コードの近くのコメントに記載